### PR TITLE
Pyseq2500 imaging

### DIFF
--- a/src/pyseq_core/base_com.py
+++ b/src/pyseq_core/base_com.py
@@ -34,16 +34,16 @@ class BaseCOM(ABC):
         return HW_CONFIG[self.name]["com"]
 
     @abstractmethod
-    async def connect(self) -> Union[str, None]:
+    async def connect(self) -> bool:
         """
         Asynchronously establishes a connection to the communication interface.
 
         Returns:
-            str: Message if the connection is successful or already exists, otherwise None.
+            bool: True if connection is successful, otherwise False.
         """
         async with self.lock:
             self._connected = True
-            pass
+        return self._connected
 
     @abstractmethod
     async def command(self, command: str, read: bool = True) -> Union[str, dict]:

--- a/src/pyseq_core/base_instruments.py
+++ b/src/pyseq_core/base_instruments.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pyseq_core.utils import HW_CONFIG
 from pyseq_core.base_com import BaseCOM
 from attrs import define, field
-from typing import Union
+from typing import Union, Awaitable
 from functools import cached_property
 import asyncio
 
@@ -32,7 +32,7 @@ class BaseInstrument(ABC):
     def config(self) -> dict:
         return HW_CONFIG[self.name]
 
-    def connect(self) -> bool:
+    def connect(self) -> Awaitable[bool]:
         return self.com.connect()
 
     async def command(self, command: Union[str, dict], **kwargs):
@@ -113,7 +113,7 @@ class BaseStage(BaseInstrument):
         """The minimum allowed position for the stage.
 
         This value is retrieved from the instrument's configuration settings
-        under the key "min_val".
+        under the key "position":"min_val".
 
         Returns:
             Union[float, int]: The minimum position.
@@ -125,12 +125,36 @@ class BaseStage(BaseInstrument):
         """The maximum allowed position for the stage.
 
         This value is retrieved from the instrument's configuration settings
-        under the key "max_val".
+        under the key "position":"max_val".
 
         Returns:
             Union[float, int]: The maximum position.
         """
         return self.config.get("position", {}).get("max_val")
+
+    @cached_property
+    def step(self) -> Union[float, int]:
+        """Stage steps between image tiles
+
+        This value is retrieved from the instrument's configuration settings
+        under the key "step".
+
+        Returns:
+            Union[float, int]: Default step size between tiles
+        """
+        return self.config.get("step", 1)
+
+    @cached_property
+    def spum(self) -> Union[float, int]:
+        """Stage steps per micron
+
+        This value is retrieved from the instrument's configuration settings
+        under the key "spum".
+
+        Returns:
+            Union[float, int]: Step per micron for stage
+        """
+        return self.config.get("spum", 1.0)
 
     @abstractmethod
     async def move(self, positiion):

--- a/src/pyseq_core/base_protocol.py
+++ b/src/pyseq_core/base_protocol.py
@@ -139,30 +139,28 @@ class BaseStagePosition(BaseModel):
     y_last: int
     z_init: int
     nz: int = -1  # Updated by experiment config NOT protocol
-    z_step: PositiveInt = HW_CONFIG["ZStage"][
-        "step"
-    ]  # Not a cached_property because want to change easily
-    x_overlap: NonNegativeFloat = 0.0
-    y_overlap: NonNegativeFloat = 0.0
+    # Not a cached_property because want to change easily
+    z_step: PositiveInt = HW_CONFIG["ZStage"]["step"]
+    overlap: NonNegativeFloat = 0.0  # in microns
 
     @computed_field
     @property
-    def x(self) -> PositiveInt:
+    def x(self) -> int:
         return self.x_init
 
     @computed_field
     @property
-    def y(self) -> PositiveInt:
+    def y(self) -> int:
         return self.y_init
 
     @computed_field
     @property
-    def z(self) -> PositiveInt:
+    def z(self) -> int:
         return self.z_init
 
     @computed_field
     @cached_property
-    def x_step(self) -> PositiveInt:
+    def x_step(self) -> int:
         return HW_CONFIG["XStage"]["step"]
 
     @computed_field
@@ -170,34 +168,48 @@ class BaseStagePosition(BaseModel):
     def y_step(self) -> int:
         return HW_CONFIG["YStage"]["step"]
 
+    @cached_property
+    def x_spum(self) -> float:
+        return HW_CONFIG["XStage"]["spum"]
+
+    @cached_property
+    def y_spum(self) -> float:
+        return HW_CONFIG["YStage"]["spum"]
+
+    @cached_property
+    def z_spum(self) -> float:
+        return HW_CONFIG["ZStage"]["spum"]
+
     @computed_field
     @property
     def nx(self) -> PositiveInt:
-        return ceil(abs(self.x_last - self.x_init) / (self.x_step - self.x_overlap))
+        nx = abs(self.x_last - self.x_init) / (self.x_step - self.overlap * self.x_spum)
+        return ceil(nx)
 
     @computed_field
     @property
     def ny(self) -> PositiveInt:
-        return ceil(abs(self.y_last - self.y_init) / (self.y_step - self.y_overlap))
+        ny = abs(self.y_last - self.y_init) / (self.y_step - self.overlap * self.y_spum)
+        return ceil(ny)
 
     @computed_field
     @property
-    def x_middle(self) -> PositiveInt:
+    def x_middle(self) -> int:
         return int((self.x_last - self.x_init) / 2 + self.x_init)
 
     @computed_field
     @property
-    def y_middle(self) -> PositiveInt:
+    def y_middle(self) -> int:
         return int((self.y_last - self.y_init) / 2 + self.y_init)
 
     @computed_field
     @property
-    def z_middle(self) -> PositiveInt:
+    def z_middle(self) -> int:
         return int((self.z_last - self.z_init) / 2 + self.z_init)
 
     @computed_field
     @property
-    def z_last(self) -> PositiveInt:
+    def z_last(self) -> int:
         return self.z_init + self.z_step * self.nz
 
     @computed_field
@@ -217,17 +229,17 @@ class BaseStagePosition(BaseModel):
 
     @field_validator("x_init", "x_last", mode="after")
     @classmethod
-    def validate_x_pos(cls, value: int) -> int:
+    def validate_x_pos(cls, value: Union[int, float]) -> Union[int, float]:
         return validate_min_max("position", value, HW_CONFIG["XStage"])
 
     @field_validator("y_init", "y_last", mode="after")
     @classmethod
-    def validate_y_pos(cls, value: int) -> int:
+    def validate_y_pos(cls, value: Union[int, float]) -> Union[int, float]:
         return validate_min_max("position", value, HW_CONFIG["YStage"])
 
     @field_validator("z_init", mode="after")
     @classmethod
-    def validate_z_pos(cls, value: int) -> int:
+    def validate_z_pos(cls, value: Union[int, float]) -> Union[int, float]:
         return validate_min_max("position", value, HW_CONFIG["ZStage"])
 
     @model_validator(mode="after")
@@ -264,6 +276,7 @@ class StageFactory:
     def factory(cls, exp_config: dict = {}) -> Type[BaseStagePosition]:
         config = exp_config.get("stage", {})
         config.update({"nz": exp_config["image"]["nz"]})
+        config.update({"overlap": exp_config["image"]["overlap"]})
 
         ExtraStageParams = create_model("ExtraStageParams", **custom_params(config))
 

--- a/src/pyseq_core/base_protocol.py
+++ b/src/pyseq_core/base_protocol.py
@@ -373,15 +373,15 @@ BaseOpticsParams = Type[OpticsParams]
 
 class ImageParams(BaseModel):
     optics: OpticsParams | None
-    output: DirectoryPath | None
+    image_dir: DirectoryPath | None
     nz: int | None
 
     @classmethod
     def factory(cls, exp_config: dict) -> Self:
         optics = OpticsParams(**exp_config["image"]["optics"])
-        output = exp_config["experiment"].get("images_path", ".")
+        image_dir = exp_config["experiment"].get("images_path", ".")
         nz = exp_config["image"]["nz"]
-        return cls(optics=optics, output=output, nz=nz)
+        return cls(optics=optics, image_dir=image_dir, nz=nz)
 
 
 # def ImageParamsFactory(exp_config: dict) -> BaseModel:

--- a/src/pyseq_core/base_system.py
+++ b/src/pyseq_core/base_system.py
@@ -165,6 +165,11 @@ class BaseSystem(ABC):
             await self._queue.get()
             self._queue.task_done()
 
+    def connect(self):
+        """Connect to instruments."""
+        description = f"Connect to {self.name} instruments"
+        self.add_task(description, self._connect)
+        
     def initialize(self):
         """Initialize the system."""
         description = f"Initialize {self.name}"
@@ -215,16 +220,16 @@ class BaseSystem(ABC):
             if not self.await_task.done():
                 await_task.cancel()
 
-    async def _initialize(self):
-        """Connect to instruments and initialize system."""
-
+    async def _connect(self):
         LOGGER.info(f"{self.name} Connecting to instruments")
         _ = []
         for instrument in self.iter_instruments:
             if instrument.com is not None:
                 _.append(instrument.connect())
-        await asyncio.gather(*_)
+        await asyncio.gather(*_)        
 
+    async def _initialize(self):
+        """Connect to instruments and initialize system."""
         LOGGER.info(f"Initializing {self.name}")
         _ = []
         for instrument in self.iter_instruments:

--- a/src/pyseq_core/base_system.py
+++ b/src/pyseq_core/base_system.py
@@ -46,6 +46,8 @@ from pathlib import Path
 from warnings import warn
 import asyncio
 import logging
+from datetime import datetime
+from functools import cached_property
 
 
 LOGGER = logging.getLogger("PySeq")
@@ -285,50 +287,52 @@ class BaseMicroscope(BaseSystem):
     name: str = field(default="microscope")
     lock_condition: asyncio.Lock = field(factory=asyncio.Lock)
 
+    @cached_property
+    def resolution(self) -> float:
+        return self.config["resolution"]
+
     @property
     def YStage(self) -> BaseStage:
-        """Abstract property for the YStage."""
-        return self.instruments.get("YStage", None)
+        """Property for the YStage."""
+        return self.instruments.get("YStage")
 
     @property
     def XStage(self) -> BaseStage:
-        """Abstract property for the XStage."""
-        return self.instruments.get("XStage", None)
+        """Property for the XStage."""
+        return self.instruments.get("XStage")
 
     @property
     def ZStage(self) -> BaseStage:
-        """Abstract property for the ZStage."""
-        return self.instruments.get("ZStage", None)
+        """Property for the ZStage."""
+        return self.instruments.get("ZStage")
 
     @property
-    def ObjStage(self) -> BaseStage:
-        """Abstract property for the ObjStage."""
-        return self.instruments.get("ObjStage", None)
+    def TiltStage(self) -> BaseStage:
+        """Property for the TiltStage."""
+        return self.instruments.get("TiltStage")
 
     @property
     def Shutter(self) -> BaseShutter:
-        """Abstract property for the Shutter."""
-        return self.instruments.get("Shutter", None)
+        """Property for the Shutter."""
+        return self.instruments.get("Shutter")
 
     @property
-    def FilterWheel(self) -> Dict[str, BaseFilter]:
-        """Abstract property for the FilterWheel.
-        Return a dictionary of FilterWheel with their respective laser color lines."""
-        return self.instruments.get("FilterWheel", {})
+    def Camera(self) -> BaseCamera:
+        """Property for the cameras."""
+        return self.instruments.get("Camera", None)
 
     @property
-    def Laser(self) -> Dict[str, BaseLaser]:
-        """Abstract property for the lasers.
+    def FilterWheels(self) -> Dict[str, BaseFilter]:
+        """Property for the FilterWheels.
+        Return a dictionary of FilterWheels with their respective laser color lines."""
+        return self.instruments.get("FilterWheels", {})
+
+    @property
+    def Lasers(self) -> Dict[str, BaseLaser]:
+        """Property for the lasers.
         Return a dictionary of lasers with their respective colors.
         """
-        return self.instruments.get("Laser", {})
-
-    @property
-    def Camera(self) -> Dict[str, BaseCamera]:
-        """Abstract property for the cameras.
-        Return a dictionary of cameras with their respective names.
-        """
-        return self.instruments.get("Camera", {})
+        return self.instruments.get("Lasers", {})
 
     @abstractmethod
     async def _capture(self, filename):
@@ -346,7 +350,7 @@ class BaseMicroscope(BaseSystem):
         pass
 
     @abstractmethod
-    async def _expose_scan(self, roi: ROIType, duration: Union[float, int]):
+    async def _expose_scan(self, roi: ROIType, duration: Union[float, int] = 0):
         """Scan over the specified region of interest (ROI) with laser."""
         pass
 
@@ -434,12 +438,42 @@ class BaseMicroscope(BaseSystem):
 
 
 def listerize_roi(func):
+    """Wrapper to connvert single ROI or dictionary of ROIs to a list"""
+
     def wrap(self, roi: Union[ROIType, List[ROIType]] = []):
         if not isinstance(roi, list):
             roi = [roi]
         if len(roi) == 0:
             roi = list(self.ROIs.values())
         return func(self, roi)
+
+    return wrap
+
+
+def timestamp(fmt: str = "%Y%m%d%H%M") -> str:
+    """Return timestamp as string"""
+    current_datetime = datetime.now()
+    return current_datetime.strftime(fmt)
+
+
+def check_name(func, fmt: str = "%Y%m%d%H%M"):
+    """Wrapper to check for image name.
+
+    Can override roi.name with name arg.
+    If no name found use current datetime formatted as fmt
+    """
+
+    def wrap(self, roi: ROIType = None, name: str = "", **kwargs):
+        if len(name) > 0:
+            pass
+        elif roi is not None:
+            try:
+                name = roi.name
+            except AttributeError:
+                name = timestamp()
+        else:
+            name = timestamp()
+        return func(self, roi=roi, name=name, **kwargs)
 
     return wrap
 
@@ -831,7 +865,7 @@ class BaseSequencer(BaseSystem):
         # Configure sequencer instruments
         _ = []
         for instrument in self.iter_instruments:
-            _.append(instrument.initialize())
+            _.append(instrument.configure())
         await asyncio.gather(*_)
 
         # Configure sub system instruments
@@ -1004,11 +1038,7 @@ class BaseSequencer(BaseSystem):
         exp_config = read_user_config(exp_config_path)
         # Set up paths for imaging, focusin, and logging and update exp_config
         exp_config = setup_experiment_path(exp_config, exp_name)
-        (
-            update_logger(
-                exp_config["logging"], exp_config["rotate_logs"]["rotate_logs"]
-            ),
-        )
+        update_logger(exp_config["logging"], exp_config["rotate_logs"]["rotate_logs"])
 
         # Reset rois and reagents
         flowcells = self._get_systems_list(fc_names)
@@ -1017,6 +1047,7 @@ class BaseSequencer(BaseSystem):
             fc.ROIs = dict()
             fc.reagents = dict()
 
+        # Configure Sequencer
         await self._configure(exp_config)
 
         # Add reagents from experiment config to flowcells
@@ -1103,6 +1134,7 @@ class BaseSequencer(BaseSystem):
                         else:
                             self.expose(flowcells=flowcell)
 
+    @staticmethod
     @abstractmethod
     def custom_roi_stage(flowcell: Union[str, int], **kwargs) -> dict:
-        pass
+        return {}

--- a/src/pyseq_core/dcam.py
+++ b/src/pyseq_core/dcam.py
@@ -140,14 +140,17 @@ class DCAMException(Exception):
 #
 # Initialization
 #
-try:
+##try:
+##    dcam = ctypes.windll.dcamapi
+##    temp = ctypes.c_int32(0)
+##    if dcam.dcam_init(None, ctypes.byref(temp), None) != DCAMERR_NOERROR:
+##        raise DCAMException("DCAM initialization failed.")
+##    n_cameras = temp.value
+##except AttributeError:
+##    warnings.warn("DCAM is not installed")
+def get_dcam():
+    global dcam
     dcam = ctypes.windll.dcamapi
-    temp = ctypes.c_int32(0)
-    if dcam.dcam_init(None, ctypes.byref(temp), None) != DCAMERR_NOERROR:
-        raise DCAMException("DCAM initialization failed.")
-    n_cameras = temp.value
-except AttributeError:
-    warnings.warn("DCAM is not installed")
 
 
 ## HCamData
@@ -170,7 +173,7 @@ class HCamData:
     #
     def __init__(self, size):
         self.np_array = np.ascontiguousarray(
-            np.empty(np.int(size / 2), dtype=np.uint16)
+            np.empty(int(size / 2), dtype=np.uint16)
         )
         self.size = size
 
@@ -230,6 +233,9 @@ class HamamatsuCamera:
          - camera_id (int): Either 0 or 1.
          - logger (logger): Logger used for messaging.
         """
+
+        if "dcam" not in globals():
+            get_dcam()
 
         self.buffer_index = 0
         self.camera_id = camera_id
@@ -809,7 +815,7 @@ class HamamatsuCamera:
         # Check that we have not acquired more frames than we can store in our buffer.
         # Keep track of the maximum backlog.
         cur_frame_number = f_count.value
-        self.message("current frame number = {cur_frame_number}")
+        self.message(f"current frame number = {cur_frame_number}")
         backlog = cur_frame_number - self.last_frame_number
         if backlog > self.number_image_buffers:
             self.message(
@@ -969,7 +975,7 @@ class HamamatsuCamera:
         error = dcam.dcam_allocframe(
             self.camera_handle, ctypes.c_int32(self.number_image_buffers)
         )
-        self.message("allocFrame, {error}")
+        self.message(f"allocFrame, {error}")
 
         return error
 

--- a/src/pyseq_core/resources/default.toml
+++ b/src/pyseq_core/resources/default.toml
@@ -11,6 +11,8 @@ protocol_path = ""
 
 [image]
 nz = 0
+overlap = 0 
+
 [image.optics]
 
 [expose]

--- a/src/pyseq_core/roi_manager.py
+++ b/src/pyseq_core/roi_manager.py
@@ -26,7 +26,7 @@ ROIType = Type[DefaultROI]
 def read_roi_config(
     flowcells: str,
     config_path: str,
-    exp_config: dict = None,
+    exp_config: dict = {},
     custom_roi_stage: Callable[[str, Union[int, str], Any], ROIType] = None,
 ) -> list[ROIType]:
     """Read ROI toml file and return list of ROIs.
@@ -251,9 +251,6 @@ class ROIManager:
         Args:
             flowcell (str): The name of the flowcell to wait for ROIs on.
         """
-
-        def roi_on_flowcell(flowcell):
-            return len(self.rois(flowcell)) > 0
 
         async with self.roi_condition:
             if len(self.rois(flowcell)) == 0:

--- a/src/sequencers/test_sequencer.py
+++ b/src/sequencers/test_sequencer.py
@@ -18,7 +18,7 @@ from pyseq_core.base_instruments import (
     BaseValve,
     BaseTemperatureController,
 )
-from pyseq_core.utils import DEFAULT_CONFIG
+from pyseq_core.utils import DEFAULT_CONFIG, HW_CONFIG
 from pyseq_core.base_com import BaseCOM
 from typing import Literal, Type, Union
 from attrs import define, field
@@ -297,11 +297,11 @@ class TestMicroscope(BaseMicroscope):
                 "Camera_558_687": TestCamera("Camera_558_687"),
                 "Camera_610_740": TestCamera("Camera_610_740"),
             },
-            "FilterWheel": {
+            "FilterWheels": {
                 "red": TestFilterWheel("red", com=COMS_DICT["redFilterWheel"]),
                 "green": TestFilterWheel("green", com=COMS_DICT["greenFilterWheel"]),
             },
-            "Laser": {
+            "Lasers": {
                 "red": TestLaser("red", com=COMS_DICT["redLaser"]),
                 "green": TestLaser("green", com=COMS_DICT["greenLaser"]),
             },
@@ -405,8 +405,8 @@ class TestMicroscope(BaseMicroscope):
         params = params.model_dump()[mode]["optics"]
         _ = []
         for color in ["red", "green"]:
-            _.append(self.Laser[color].set_power(params["power"][color]))
-            _.append(self.FilterWheel[color].set_filter(params["filter"][color]))
+            _.append(self.Lasers[color].set_power(params["power"][color]))
+            _.append(self.FilterWheels[color].set_filter(params["filter"][color]))
 
         if mode in ["image", "focus"]:
             for c in self.Camera:
@@ -457,7 +457,8 @@ class TestSequencer(BaseSequencer):
     # async def _configure(self, exp_config):
     #     LOGGER.debug(f"Configuring {self.name}")
 
-    def custom_roi_stage(self, flowcell: Union[str, int], **kwargs) -> ROIType:
+    @staticmethod
+    def custom_roi_stage(flowcell: Union[str, int], **kwargs) -> ROIType:
         """Take LLx, LLy, URx, URy coordinates and return stage position parameters."""
         LLx = kwargs.pop("LLx") * 100
         LLy = kwargs.pop("LLy") * 100
@@ -465,11 +466,11 @@ class TestSequencer(BaseSequencer):
         URy = kwargs.pop("URy") * 100
 
         # x, y, Steps Per UMicron
-        x_spum = self._config["XStage"]["spum"]
-        y_spum = self._config["YStage"]["spum"]
+        x_spum = HW_CONFIG["XStage"]["spum"]
+        y_spum = HW_CONFIG["YStage"]["spum"]
         # x, y origin
-        x_origin = self._config["XStage"]["origin"][flowcell]
-        y_origin = self._config["YStage"]["origin"]
+        x_origin = HW_CONFIG["XStage"]["origin"][flowcell]
+        y_origin = HW_CONFIG["YStage"]["origin"]
         # x_origin = self.microscope.XStage.config["origin"][fc]
         # y_origin = self.microscope.YStage.config["origin"]
 


### PR DESCRIPTION
## Description

Made changes to fix bugs in the pyseq2500 imaging routines.
Changed BaseROI.image.output -> BaseROI.image.image_dir
Do not load dcam in main, moved to inside function dcam.get_dcam
Add a wrapper to check for image names and add a default timestamp if not found

## Related Issue(s)
PR Imaging Routines in PySeq2500

## How Has This Been Tested?
uv run pytest
all tests passed

## Checklist

- [x] I have read the Contributer Guidelines
- [x] I have performed a self-review of my own code.
- [x] I have added comments to my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
